### PR TITLE
Use cross-spawn for windows compatibility

### DIFF
--- a/bin/bstalk
+++ b/bin/bstalk
@@ -3,7 +3,7 @@
 var exists = require('fs').existsSync,
     program = require('commander'),
     resolve = require('path').resolve,
-    spawn = require('child_process').spawn,
+    spawn = require('cross-spawn'),
     config = require('nconf'),
     fs      = require("fs"),
     path    = require("path"),

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cli-spinner": "^0.2.5",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
+    "cross-spawn": "^4.0.0",
     "indent": "0.0.2",
     "nconf": "^0.8.4",
     "open": "0.0.5",


### PR DESCRIPTION
Launching any  bstalk subcommand (ex bstalk config) fails on my windows but using node cross-spawn seems to fix everything 
https://github.com/IndigoUnited/node-cross-spawn
